### PR TITLE
Fix trait overlay missing when query_gene finds zero variants

### DIFF
--- a/src/genechat/tools/query_gene.py
+++ b/src/genechat/tools/query_gene.py
@@ -194,10 +194,11 @@ def register(mcp, engine, db, config):
                 lines.append(f"| {rsid} | {pos} | {gt} | {effect} | {impact} | {sig} |")
         elif suppressed_count == 0:
             lines.append(
-                f"No {'/'.join(impacts)} impact variants found. "
-                "Your sequence matches the reference genome in this region "
-                "for the impact levels queried. Try broadening the impact filter "
-                "(e.g. impact_filter='HIGH,MODERATE,LOW,MODIFIER') to see all variants."
+                f"No {'/'.join(impacts)} impact variants found in the returned results "
+                "for this region. Try broadening the impact filter "
+                "(e.g. impact_filter='HIGH,MODERATE,LOW,MODIFIER') to see more variants. "
+                "Note: unannotated variants without rsID or ClinVar data are excluded "
+                "by default."
             )
         else:
             lines.append("No clinically notable variants remain after filtering.")


### PR DESCRIPTION
## Summary
- Fixes `query_gene` trait overlay not showing for genes with no coding variants but known trait associations
- FOXO3 (longevity rs2802292), CLOCK, and similar genes now show trait data with genotypes even when the main variant table is empty
- Root cause: early return at line 157 exited before the trait overlay code could run
- Fix: removed early return, restructured so all three sections (variant table / no-variants message / trait overlay) always execute

## Test plan
- [x] `uv run pytest -x` — 201 passed, 57 skipped
- [x] Existing `test_no_variants` still passes (assertion updated to match new format)
- [ ] Manual: `query_gene("FOXO3")` — should show trait overlay with rs2802292 longevity association
- [ ] Manual: `query_gene("MTHFR")` — should show both variant table AND trait overlay (regression check)

🤖 Generated with [Claude Code](https://claude.ai/code)