### PR TITLE
Fix stale annotated VCF references

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ At runtime, GeneChat uses **only** local files — no external tools, no network
 
 | Library | What it does |
 |---------|-------------|
-| [pysam](https://pysam.readthedocs.io/) | Reads your annotated VCF via tabix index |
+| [pysam](https://pysam.readthedocs.io/) | Reads your raw VCF via tabix index |
 | [mcp](https://github.com/anthropics/python-sdk) | Implements the MCP server protocol |
 | SQLite (stdlib) | Queries lookup tables for gene coordinates, drug info, PRS weights |
 | [pydantic](https://docs.pydantic.dev/) | Validates tool inputs and config |
@@ -292,7 +292,7 @@ E2e tests are automatically skipped when `GENECHAT_GIAB_VCF` is not set.
 
 ## Troubleshooting
 
-**Missing VCF index (.tbi):** `tabix -p vcf /path/to/your/annotated.vcf.gz`
+**Missing VCF index (.tbi):** `tabix -p vcf /path/to/your/raw.vcf.gz`
 
 **Wrong genome build:** GeneChat expects GRCh38 with `chr` prefixed chromosomes. GRCh37/hg19 VCFs need liftover first.
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -7,7 +7,7 @@
 # The first genome listed is the primary (default) genome.
 
 [genomes.personal]
-vcf_path = "/path/to/your/annotated.vcf.gz"
+vcf_path = "/path/to/your/raw.vcf.gz"
 genome_build = "GRCh38"
 # patch_db = ""  # Auto-derived from VCF path if not set
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,11 +17,11 @@ hdiutil create -size 5g -fs APFS -encryption AES-256 \
 hdiutil attach ~/GenomeData.sparseimage
 
 # Your VCF goes in /Volumes/GenomeData/
-cp /path/to/annotated.vcf.gz /Volumes/GenomeData/
-cp /path/to/annotated.vcf.gz.tbi /Volumes/GenomeData/
+cp /path/to/raw.vcf.gz /Volumes/GenomeData/
+cp /path/to/raw.vcf.gz.tbi /Volumes/GenomeData/
 
 # Point config.toml at the mounted volume
-# vcf_path = "/Volumes/GenomeData/annotated.vcf.gz"
+# vcf_path = "/Volumes/GenomeData/raw.vcf.gz"
 
 # Unmount when not in use
 hdiutil detach /Volumes/GenomeData
@@ -52,7 +52,7 @@ For additional isolation, store your VCF on an external encrypted USB drive. Use
 Restrict access to your VCF and config file:
 
 ```bash
-chmod 600 /path/to/annotated.vcf.gz /path/to/annotated.vcf.gz.tbi
+chmod 600 /path/to/raw.vcf.gz /path/to/raw.vcf.gz.tbi
 chmod 600 /path/to/config.toml
 ```
 


### PR DESCRIPTION
## Summary
- Update remaining "annotated.vcf.gz" references to "raw.vcf.gz" across config.toml.example, README.md, and docs/security.md
- Legacy annotated-VCF mode was removed in PR #33 — the raw VCF is never modified, annotations live in patch.db
- Completes Part 2 (doc fixes) of the corrective actions plan

## Architecture
- [x] No architectural decision needed

## Test plan
- [x] Tests pass (`uv run pytest -x`) — 263 passed, 45 skipped
- [x] Lint clean (`uv run ruff check . && uv run ruff format --check .`)
- [x] Verify no remaining "annotated.vcf.gz" references in repo

🤖 Generated with [Claude Code](https://claude.ai/code)