### PR TITLE
ux: rename 'Lookup tables' to 'Seeds' in status output

### DIFF
--- a/src/genechat/cli.py
+++ b/src/genechat/cli.py
@@ -1848,7 +1848,7 @@ def _run_status(json_output: bool = False, check_updates: bool = False):
         print("  GWAS:           installed (CC0)")
     else:
         print("  GWAS:           not installed — genechat install --gwas")
-    print("  Lookup tables:  installed")
+    print("  Seeds:          installed")
     print()
 
     # Section 2: Per-genome annotation state


### PR DESCRIPTION
## Summary
- Renames the "Lookup tables" label to "Seeds" in `genechat status` output to match the CLI terminology (`genechat install --seeds`)

Fixes #73

## Test plan
- [x] All 399 tests pass (no tests assert on the old label string)
- [x] Manual: run `genechat status` and verify the line reads `Seeds: installed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)