### PR TITLE
feat: make data directory configurable via env var and config

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -18,9 +18,9 @@ genome_build = "GRCh38"
 
 # --- Databases ---
 [databases]
-data_dir = ""   # Override base data directory (default: ~/.local/share/genechat)
-                # Also settable via GENECHAT_DATA_DIR env var.
-                # Useful for containers/cloud where home is ephemeral.
+data_dir = ""   # Override base data directory (default: OS-specific, e.g.
+                # ~/.local/share/genechat on Linux/macOS). Also settable via
+                # GENECHAT_DATA_DIR env var. Useful for containers/cloud.
 lookup_db = ""  # Leave empty to use built-in package data
 gwas_db = ""    # Leave empty to use <data_dir>/gwas.db
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -18,8 +18,11 @@ genome_build = "GRCh38"
 
 # --- Databases ---
 [databases]
+data_dir = ""   # Override base data directory (default: ~/.local/share/genechat)
+                # Also settable via GENECHAT_DATA_DIR env var.
+                # Useful for containers/cloud where home is ephemeral.
 lookup_db = ""  # Leave empty to use built-in package data
-gwas_db = ""    # Leave empty to use ~/.local/share/genechat/gwas.db
+gwas_db = ""    # Leave empty to use <data_dir>/gwas.db
 
 # --- Server ---
 [server]

--- a/scripts/build_gwas_db.py
+++ b/scripts/build_gwas_db.py
@@ -7,9 +7,9 @@ Thin wrapper around genechat.gwas module. For direct use:
 import sys
 from pathlib import Path
 
-from genechat.gwas import _default_gwas_db, _default_gwas_zip, build_gwas_db
+from genechat.gwas import default_gwas_db, default_gwas_zip, build_gwas_db
 
 if __name__ == "__main__":
-    zip_path = Path(sys.argv[1]) if len(sys.argv) > 1 else _default_gwas_zip()
-    db_path = Path(sys.argv[2]) if len(sys.argv) > 2 else _default_gwas_db()
+    zip_path = Path(sys.argv[1]) if len(sys.argv) > 1 else default_gwas_zip()
+    db_path = Path(sys.argv[2]) if len(sys.argv) > 2 else default_gwas_db()
     build_gwas_db(zip_path, db_path)

--- a/scripts/build_gwas_db.py
+++ b/scripts/build_gwas_db.py
@@ -7,9 +7,9 @@ Thin wrapper around genechat.gwas module. For direct use:
 import sys
 from pathlib import Path
 
-from genechat.gwas import DEFAULT_GWAS_DB, DEFAULT_GWAS_ZIP, build_gwas_db
+from genechat.gwas import _default_gwas_db, _default_gwas_zip, build_gwas_db
 
 if __name__ == "__main__":
-    zip_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_GWAS_ZIP
-    db_path = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_GWAS_DB
+    zip_path = Path(sys.argv[1]) if len(sys.argv) > 1 else _default_gwas_zip()
+    db_path = Path(sys.argv[2]) if len(sys.argv) > 2 else _default_gwas_db()
     build_gwas_db(zip_path, db_path)

--- a/src/genechat/config.py
+++ b/src/genechat/config.py
@@ -62,9 +62,9 @@ class AppConfig(BaseModel):
 def get_data_dir() -> Path:
     """Base directory for user data (references, GWAS, lookup tables).
 
-    Resolution order: GENECHAT_DATA_DIR env var → platformdirs default.
-    The config.toml ``data_dir`` setting is propagated to the env var
-    in ``load_config()`` so all modules pick it up.
+    Resolution order: GENECHAT_DATA_DIR env var → config.toml
+    ``[databases].data_dir`` (propagated to the env var by
+    ``load_config()``) → platformdirs default.
     """
     env = os.environ.get("GENECHAT_DATA_DIR")
     if env:

--- a/src/genechat/config.py
+++ b/src/genechat/config.py
@@ -63,10 +63,13 @@ def get_data_dir() -> Path:
     """Base directory for user data (references, GWAS, lookup tables).
 
     Resolution order: GENECHAT_DATA_DIR env var → platformdirs default.
-    The config.toml ``data_dir`` setting is applied by the CLI at startup
-    by setting the env var before any module reads it.
+    The config.toml ``data_dir`` setting is propagated to the env var
+    in ``load_config()`` so all modules pick it up.
     """
-    return Path(os.environ.get("GENECHAT_DATA_DIR") or user_data_dir("genechat"))
+    env = os.environ.get("GENECHAT_DATA_DIR")
+    if env:
+        return Path(env).expanduser()
+    return Path(user_data_dir("genechat"))
 
 
 def _user_db_path() -> Path:
@@ -257,6 +260,8 @@ def load_config(path: str | None = None) -> AppConfig:
     # Propagate data_dir from config to env var so all modules
     # (download.py, gwas.py) pick it up via get_data_dir().
     if config.databases.data_dir and not os.environ.get("GENECHAT_DATA_DIR"):
-        os.environ["GENECHAT_DATA_DIR"] = config.databases.data_dir
+        os.environ["GENECHAT_DATA_DIR"] = str(
+            Path(config.databases.data_dir).expanduser()
+        )
 
     return config

--- a/src/genechat/config.py
+++ b/src/genechat/config.py
@@ -17,6 +17,7 @@ class GenomeConfig(BaseModel):
 
 
 class DatabasesConfig(BaseModel):
+    data_dir: str = ""
     lookup_db: str = ""
     gwas_db: str = ""
 
@@ -58,9 +59,19 @@ class AppConfig(BaseModel):
         return str(gwas_db_path())
 
 
+def get_data_dir() -> Path:
+    """Base directory for user data (references, GWAS, lookup tables).
+
+    Resolution order: GENECHAT_DATA_DIR env var → platformdirs default.
+    The config.toml ``data_dir`` setting is applied by the CLI at startup
+    by setting the env var before any module reads it.
+    """
+    return Path(os.environ.get("GENECHAT_DATA_DIR") or user_data_dir("genechat"))
+
+
 def _user_db_path() -> Path:
     """User-writable lookup_tables.db location (rebuilt by genechat install --seeds)."""
-    return Path(user_data_dir("genechat")) / "lookup_tables.db"
+    return get_data_dir() / "lookup_tables.db"
 
 
 def _default_db_path() -> Path:
@@ -242,5 +253,10 @@ def load_config(path: str | None = None) -> AppConfig:
         config = AppConfig(**data)
     else:
         config = AppConfig()
+
+    # Propagate data_dir from config to env var so all modules
+    # (download.py, gwas.py) pick it up via get_data_dir().
+    if config.databases.data_dir and not os.environ.get("GENECHAT_DATA_DIR"):
+        os.environ["GENECHAT_DATA_DIR"] = config.databases.data_dir
 
     return config

--- a/src/genechat/download.py
+++ b/src/genechat/download.py
@@ -13,11 +13,8 @@ import time
 from pathlib import Path
 from urllib.request import Request, urlopen
 
-from platformdirs import user_data_dir
-
+from genechat.config import get_data_dir
 from genechat.progress import ProgressLine, format_size, format_speed
-
-REFERENCES_DIR = Path(user_data_dir("genechat")) / "references"
 
 CLINVAR_URL = "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz"
 CLINVAR_TBI_URL = (
@@ -66,8 +63,9 @@ DBSNP_CONTIGS = [
 
 def references_dir() -> Path:
     """Return the shared references directory, creating it if needed."""
-    REFERENCES_DIR.mkdir(parents=True, exist_ok=True)
-    return REFERENCES_DIR
+    d = get_data_dir() / "references"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 
 def clinvar_path() -> Path:

--- a/src/genechat/download.py
+++ b/src/genechat/download.py
@@ -1,7 +1,8 @@
 """Download reference databases for GeneChat annotation.
 
-Downloads to a shared cache directory (~/.local/share/genechat/references/
-via platformdirs). References are genome-build-specific, not sample-specific.
+Downloads to a shared cache directory under the configurable data dir
+(see ``genechat.config.get_data_dir``). References are genome-build-specific,
+not sample-specific.
 """
 
 import json

--- a/src/genechat/gwas.py
+++ b/src/genechat/gwas.py
@@ -13,17 +13,12 @@ import sqlite3
 import zipfile
 from pathlib import Path
 
-from platformdirs import user_data_dir
+from genechat.config import get_data_dir
 
 GWAS_URL = (
     "https://ftp.ebi.ac.uk/pub/databases/gwas/releases/latest/"
     "gwas-catalog-associations_ontology-annotated-full.zip"
 )
-
-# Default paths
-GWAS_DATA_DIR = Path(user_data_dir("genechat"))
-DEFAULT_GWAS_DB = GWAS_DATA_DIR / "gwas.db"
-DEFAULT_GWAS_ZIP = GWAS_DATA_DIR / "gwas-catalog-associations.zip"
 
 # Columns we extract (index in GWAS catalog TSV)
 COL_TRAIT = 7  # DISEASE/TRAIT
@@ -124,11 +119,19 @@ def _normalize_chrom(chrom: str) -> str | None:
     return None
 
 
+def _default_gwas_db() -> Path:
+    return get_data_dir() / "gwas.db"
+
+
+def _default_gwas_zip() -> Path:
+    return get_data_dir() / "gwas-catalog-associations.zip"
+
+
 def download_gwas_catalog(dest_path: Path | None = None) -> Path:
     """Download the GWAS Catalog associations zip. Returns path to the zip."""
     from genechat.download import download_file
 
-    zip_path = dest_path or DEFAULT_GWAS_ZIP
+    zip_path = dest_path or _default_gwas_zip()
     zip_path.parent.mkdir(parents=True, exist_ok=True)
     download_file(GWAS_URL, zip_path, "GWAS Catalog")
     return zip_path
@@ -141,8 +144,8 @@ def build_gwas_db(zip_path: Path | None = None, db_path: Path | None = None) -> 
     Deletes the zip after a successful build when using the default cache path.
     """
     using_default_zip = zip_path is None
-    zip_path = zip_path or DEFAULT_GWAS_ZIP
-    db_path = db_path or DEFAULT_GWAS_DB
+    zip_path = zip_path or _default_gwas_zip()
+    db_path = db_path or _default_gwas_db()
 
     if not zip_path.exists():
         download_gwas_catalog(zip_path)
@@ -243,9 +246,9 @@ def build_gwas_db(zip_path: Path | None = None, db_path: Path | None = None) -> 
 
 def gwas_db_path() -> Path:
     """Return the default GWAS DB path."""
-    return DEFAULT_GWAS_DB
+    return _default_gwas_db()
 
 
 def gwas_installed() -> bool:
     """Check if the GWAS DB has been downloaded and built."""
-    return DEFAULT_GWAS_DB.exists()
+    return _default_gwas_db().exists()

--- a/src/genechat/gwas.py
+++ b/src/genechat/gwas.py
@@ -119,11 +119,11 @@ def _normalize_chrom(chrom: str) -> str | None:
     return None
 
 
-def _default_gwas_db() -> Path:
+def default_gwas_db() -> Path:
     return get_data_dir() / "gwas.db"
 
 
-def _default_gwas_zip() -> Path:
+def default_gwas_zip() -> Path:
     return get_data_dir() / "gwas-catalog-associations.zip"
 
 
@@ -131,7 +131,7 @@ def download_gwas_catalog(dest_path: Path | None = None) -> Path:
     """Download the GWAS Catalog associations zip. Returns path to the zip."""
     from genechat.download import download_file
 
-    zip_path = dest_path or _default_gwas_zip()
+    zip_path = dest_path or default_gwas_zip()
     zip_path.parent.mkdir(parents=True, exist_ok=True)
     download_file(GWAS_URL, zip_path, "GWAS Catalog")
     return zip_path
@@ -144,8 +144,8 @@ def build_gwas_db(zip_path: Path | None = None, db_path: Path | None = None) -> 
     Deletes the zip after a successful build when using the default cache path.
     """
     using_default_zip = zip_path is None
-    zip_path = zip_path or _default_gwas_zip()
-    db_path = db_path or _default_gwas_db()
+    zip_path = zip_path or default_gwas_zip()
+    db_path = db_path or default_gwas_db()
 
     if not zip_path.exists():
         download_gwas_catalog(zip_path)
@@ -246,9 +246,9 @@ def build_gwas_db(zip_path: Path | None = None, db_path: Path | None = None) -> 
 
 def gwas_db_path() -> Path:
     """Return the default GWAS DB path."""
-    return _default_gwas_db()
+    return default_gwas_db()
 
 
 def gwas_installed() -> bool:
     """Check if the GWAS DB has been downloaded and built."""
-    return _default_gwas_db().exists()
+    return default_gwas_db().exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,13 @@
 import importlib.resources as _real_resources
 from pathlib import Path
 
-from genechat.config import AppConfig, _default_db_path, load_config, write_config
+from genechat.config import (
+    AppConfig,
+    _default_db_path,
+    get_data_dir,
+    load_config,
+    write_config,
+)
 
 
 class TestAppConfig:
@@ -148,3 +154,45 @@ class TestLoadConfig:
         assert len(config.genomes) == 2
         assert config.genomes["nate"].vcf_path == "/nate.vcf.gz"
         assert config.genomes["partner"].vcf_path == "/partner.vcf.gz"
+
+    def test_data_dir_propagated_to_env(self, tmp_path, monkeypatch):
+        """data_dir from config.toml is propagated to GENECHAT_DATA_DIR env var."""
+        monkeypatch.delenv("GENECHAT_DATA_DIR", raising=False)
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[databases]\ndata_dir = "/data/genechat"\n\n'
+            '[genomes.test]\nvcf_path = "/test.vcf.gz"\n'
+        )
+        load_config(str(config_file))
+        import os
+
+        assert os.environ.get("GENECHAT_DATA_DIR") == "/data/genechat"
+        # Clean up
+        monkeypatch.delenv("GENECHAT_DATA_DIR")
+
+    def test_env_var_takes_precedence_over_config_data_dir(self, tmp_path, monkeypatch):
+        """GENECHAT_DATA_DIR env var takes precedence over config.toml data_dir."""
+        monkeypatch.setenv("GENECHAT_DATA_DIR", "/env/override")
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[databases]\ndata_dir = "/config/path"\n\n'
+            '[genomes.test]\nvcf_path = "/test.vcf.gz"\n'
+        )
+        load_config(str(config_file))
+        import os
+
+        # Env var should NOT be overwritten by config
+        assert os.environ.get("GENECHAT_DATA_DIR") == "/env/override"
+
+
+class TestGetDataDir:
+    def test_env_var_override(self, monkeypatch):
+        monkeypatch.setenv("GENECHAT_DATA_DIR", "/custom/data")
+        assert get_data_dir() == Path("/custom/data")
+
+    def test_falls_back_to_platformdirs(self, monkeypatch):
+        monkeypatch.delenv("GENECHAT_DATA_DIR", raising=False)
+        result = get_data_dir()
+        # Should return the platformdirs default (varies by OS)
+        assert isinstance(result, Path)
+        assert "genechat" in str(result)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,6 +190,12 @@ class TestGetDataDir:
         monkeypatch.setenv("GENECHAT_DATA_DIR", "/custom/data")
         assert get_data_dir() == Path("/custom/data")
 
+    def test_tilde_expanded(self, monkeypatch):
+        monkeypatch.setenv("GENECHAT_DATA_DIR", "~/genechat-data")
+        result = get_data_dir()
+        assert "~" not in str(result)
+        assert str(result).endswith("genechat-data")
+
     def test_falls_back_to_platformdirs(self, monkeypatch):
         monkeypatch.delenv("GENECHAT_DATA_DIR", raising=False)
         result = get_data_dir()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,8 +167,6 @@ class TestLoadConfig:
         import os
 
         assert os.environ.get("GENECHAT_DATA_DIR") == "/data/genechat"
-        # Clean up
-        monkeypatch.delenv("GENECHAT_DATA_DIR")
 
     def test_env_var_takes_precedence_over_config_data_dir(self, tmp_path, monkeypatch):
         """GENECHAT_DATA_DIR env var takes precedence over config.toml data_dir."""

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -29,57 +29,55 @@ from genechat.download import (
 
 class TestPaths:
     def test_references_dir_creates_directory(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         result = references_dir()
         assert result.exists()
-        assert result == tmp_path / "refs"
+        assert result == tmp_path / "references"
 
     def test_clinvar_path(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         assert clinvar_path().name == "clinvar.vcf.gz"
 
     def test_clinvar_tbi_path(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         assert clinvar_tbi_path().name == "clinvar.vcf.gz.tbi"
 
 
 class TestInstalled:
     def test_clinvar_installed_true(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        refs = tmp_path / "references"
         refs.mkdir()
         (refs / "clinvar.vcf.gz").write_bytes(b"fake")
         (refs / "clinvar.vcf.gz.tbi").write_bytes(b"fake")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         assert clinvar_installed() is True
 
     def test_clinvar_installed_false(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        refs = tmp_path / "references"
         refs.mkdir()
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         assert clinvar_installed() is False
 
     def test_gnomad_installed_false(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         assert gnomad_installed() is False
 
     def test_gnomad_installed_true(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        gdir = refs / "gnomad_exomes_v4"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        gdir = tmp_path / "references" / "gnomad_exomes_v4"
         gdir.mkdir(parents=True)
         for c in GNOMAD_CHROMS:
             (gdir / f"gnomad.exomes.v4.1.sites.chr{c}.vcf.bgz").write_bytes(b"x")
             (gdir / f"gnomad.exomes.v4.1.sites.chr{c}.vcf.bgz.tbi").write_bytes(b"x")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         assert gnomad_installed() is True
 
     def test_gnomad_installed_missing_tbi(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        gdir = refs / "gnomad_exomes_v4"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        gdir = tmp_path / "references" / "gnomad_exomes_v4"
         gdir.mkdir(parents=True)
         for c in GNOMAD_CHROMS:
             (gdir / f"gnomad.exomes.v4.1.sites.chr{c}.vcf.bgz").write_bytes(b"x")
         # No .tbi files
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         assert gnomad_installed() is False
 
     def test_snpeff_installed(self, monkeypatch):
@@ -93,11 +91,11 @@ class TestInstalled:
 
 class TestDownloadClinvar:
     def test_skips_when_existing(self, monkeypatch, tmp_path, capsys):
-        refs = tmp_path / "refs"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        refs = tmp_path / "references"
         refs.mkdir()
         (refs / "clinvar.vcf.gz").write_bytes(b"fake")
         (refs / "clinvar.vcf.gz.tbi").write_bytes(b"fake")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
 
         result = download_clinvar()
         assert result == refs / "clinvar.vcf.gz"
@@ -139,52 +137,49 @@ class TestDetectSnpeffDb:
 
 class TestDbsnpPaths:
     def test_dbsnp_dir(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         d = dbsnp_dir()
-        assert d == tmp_path / "refs" / "dbsnp"
+        assert d == tmp_path / "references" / "dbsnp"
 
     def test_dbsnp_raw_path(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         assert dbsnp_raw_path().name == "GCF_000001405.40.gz"
 
     def test_dbsnp_path(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         assert dbsnp_path().name == "dbsnp_chrfixed.vcf.gz"
 
 
 class TestDbsnpInstalled:
     def test_false_when_missing(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         assert dbsnp_installed() is False
 
     def test_false_when_no_tbi(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        ddir = refs / "dbsnp"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
         (ddir / "dbsnp_chrfixed.vcf.gz").write_bytes(b"fake")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         assert dbsnp_installed() is False
 
     def test_true_when_both_exist(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        ddir = refs / "dbsnp"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
         (ddir / "dbsnp_chrfixed.vcf.gz").write_bytes(b"fake")
         (ddir / "dbsnp_chrfixed.vcf.gz.tbi").write_bytes(b"fake")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         assert dbsnp_installed() is True
 
 
 class TestDbsnpState:
     def test_load_empty_when_no_file(self, monkeypatch, tmp_path):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
-        (tmp_path / "refs" / "dbsnp").mkdir(parents=True)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        (tmp_path / "references" / "dbsnp").mkdir(parents=True)
         assert _load_dbsnp_state() == {}
 
     def test_save_and_load_roundtrip(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        (refs / "dbsnp").mkdir(parents=True)
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        (tmp_path / "references" / "dbsnp").mkdir(parents=True)
 
         state = {"completed_contigs": ["NC_000001.11", "NC_000002.12"]}
         _save_dbsnp_state(state)
@@ -192,10 +187,9 @@ class TestDbsnpState:
         assert loaded == state
 
     def test_load_returns_empty_on_corrupt_json(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        ddir = refs / "dbsnp"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
 
         (ddir / "dbsnp_progress.json").write_text("not valid json{{{")
         assert _load_dbsnp_state() == {}
@@ -203,12 +197,11 @@ class TestDbsnpState:
 
 class TestDbsnpDownload:
     def test_skips_when_existing(self, monkeypatch, tmp_path, capsys):
-        refs = tmp_path / "refs"
-        ddir = refs / "dbsnp"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
         (ddir / "dbsnp_chrfixed.vcf.gz").write_bytes(b"fake")
         (ddir / "dbsnp_chrfixed.vcf.gz.tbi").write_bytes(b"fake")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         # Ensure test is hermetic even without bcftools/tabix on PATH
         monkeypatch.setattr("shutil.which", lambda name: None)
 
@@ -217,7 +210,7 @@ class TestDbsnpDownload:
         assert "already downloaded" in capsys.readouterr().out
 
     def test_fails_without_bcftools(self, monkeypatch, tmp_path, capsys):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         monkeypatch.setattr("shutil.which", lambda name: None)
 
         result = download_dbsnp()
@@ -225,7 +218,7 @@ class TestDbsnpDownload:
         assert "bcftools not found" in capsys.readouterr().err
 
     def test_fails_without_tabix(self, monkeypatch, tmp_path, capsys):
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", tmp_path / "refs")
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         monkeypatch.setattr(
             "shutil.which",
             lambda name: "/usr/bin/bcftools" if name == "bcftools" else None,
@@ -237,8 +230,7 @@ class TestDbsnpDownload:
 
     def test_per_chromosome_pipeline(self, monkeypatch, tmp_path, capsys):
         """Verify per-chromosome download, concat, and cleanup."""
-        refs = tmp_path / "refs"
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
 
         # Use only 2 contigs for speed
@@ -268,14 +260,14 @@ class TestDbsnpDownload:
         # State file should be cleaned up
         assert not _dbsnp_state_path().exists()
         # Per-chromosome dir should be cleaned up
+        refs = tmp_path / "references"
         assert not (refs / "dbsnp" / "per_chrom").exists()
 
     def test_resume_skips_completed(self, monkeypatch, tmp_path, capsys):
         """Verify completed chromosomes are skipped on resume."""
-        refs = tmp_path / "refs"
-        ddir = refs / "dbsnp"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
 
         monkeypatch.setattr(
@@ -315,10 +307,9 @@ class TestDbsnpDownload:
 
     def test_force_ignores_state(self, monkeypatch, tmp_path, capsys):
         """Verify --force re-downloads all chromosomes."""
-        refs = tmp_path / "refs"
-        ddir = refs / "dbsnp"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
 
         monkeypatch.setattr(
@@ -355,11 +346,10 @@ class TestDbsnpDownload:
         """Verify legacy raw file triggers file-based rename path."""
         import subprocess
 
-        refs = tmp_path / "refs"
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
 
-        ddir = refs / "dbsnp"
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
         raw = ddir / "GCF_000001405.40.gz"
         raw.write_bytes(b"fake-vcf-data")
@@ -389,8 +379,7 @@ class TestDbsnpDownload:
         """Verify state is preserved when a chromosome fails mid-way."""
         import subprocess
 
-        refs = tmp_path / "refs"
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
 
         monkeypatch.setattr(
@@ -420,14 +409,14 @@ class TestDbsnpDownload:
 
         # State should show chr21 as complete
         state = _load_dbsnp_state()
+        assert "NC_000001.11" not in state.get("completed_contigs", [])
         assert "NC_000021.9" in state.get("completed_contigs", [])
         # chr22 failed, so should not be in completed
         assert "NC_000022.11" not in state.get("completed_contigs", [])
 
     def test_fast_downloads_raw_and_renames(self, monkeypatch, tmp_path, capsys):
         """fast=True downloads full file then uses file-based rename."""
-        refs = tmp_path / "refs"
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
         monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
 
         downloaded = []
@@ -480,12 +469,11 @@ class TestDbsnpDownload:
 
     def test_fast_skips_when_existing(self, monkeypatch, tmp_path, capsys):
         """fast=True still skips when chrfixed already exists."""
-        refs = tmp_path / "refs"
-        ddir = refs / "dbsnp"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        ddir = tmp_path / "references" / "dbsnp"
         ddir.mkdir(parents=True)
         (ddir / "dbsnp_chrfixed.vcf.gz").write_bytes(b"fake")
         (ddir / "dbsnp_chrfixed.vcf.gz.tbi").write_bytes(b"fake")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
         monkeypatch.setattr("shutil.which", lambda name: None)
 
         result = download_dbsnp(fast=True)
@@ -654,8 +642,7 @@ class TestConcatDbsnpChromosomes:
 
 class TestDownloadGnomadChr:
     def test_downloads_vcf_and_tbi(self, monkeypatch, tmp_path, capsys):
-        refs = tmp_path / "refs"
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
 
         downloaded = []
 
@@ -672,12 +659,11 @@ class TestDownloadGnomadChr:
         assert "gnomad.exomes.v4.1.sites.chr1.vcf.bgz.tbi" in downloaded
 
     def test_skips_existing(self, monkeypatch, tmp_path, capsys):
-        refs = tmp_path / "refs"
-        gdir = refs / "gnomad_exomes_v4"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        gdir = tmp_path / "references" / "gnomad_exomes_v4"
         gdir.mkdir(parents=True)
         (gdir / "gnomad.exomes.v4.1.sites.chr1.vcf.bgz").write_bytes(b"x")
         (gdir / "gnomad.exomes.v4.1.sites.chr1.vcf.bgz.tbi").write_bytes(b"x")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
 
         downloaded = []
         monkeypatch.setattr(
@@ -691,12 +677,11 @@ class TestDownloadGnomadChr:
 
     def test_redownloads_when_tbi_missing(self, monkeypatch, tmp_path):
         """VCF+TBI are an atomic pair; missing TBI triggers re-download of both."""
-        refs = tmp_path / "refs"
-        gdir = refs / "gnomad_exomes_v4"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        gdir = tmp_path / "references" / "gnomad_exomes_v4"
         gdir.mkdir(parents=True)
         (gdir / "gnomad.exomes.v4.1.sites.chr1.vcf.bgz").write_bytes(b"x")
         # No .tbi file
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
 
         downloaded = []
 
@@ -714,23 +699,21 @@ class TestDownloadGnomadChr:
 
 class TestDeleteGnomadChr:
     def test_deletes_vcf_and_tbi(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        gdir = refs / "gnomad_exomes_v4"
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        gdir = tmp_path / "references" / "gnomad_exomes_v4"
         gdir.mkdir(parents=True)
         vcf = gdir / "gnomad.exomes.v4.1.sites.chr1.vcf.bgz"
         tbi = gdir / "gnomad.exomes.v4.1.sites.chr1.vcf.bgz.tbi"
         vcf.write_bytes(b"x")
         tbi.write_bytes(b"x")
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
 
         delete_gnomad_chr("1")
         assert not vcf.exists()
         assert not tbi.exists()
 
     def test_no_error_when_missing(self, monkeypatch, tmp_path):
-        refs = tmp_path / "refs"
-        refs.mkdir(parents=True)
-        monkeypatch.setattr("genechat.download.REFERENCES_DIR", refs)
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        (tmp_path / "references").mkdir(parents=True)
 
         # Should not raise
         delete_gnomad_chr("1")

--- a/tests/test_gwas.py
+++ b/tests/test_gwas.py
@@ -57,10 +57,8 @@ class TestGwasDbPath:
         assert isinstance(p, Path)
         assert p.name == "gwas.db"
 
-    def test_gwas_installed_false_when_no_db(self, monkeypatch):
-        monkeypatch.setattr(
-            "genechat.gwas.DEFAULT_GWAS_DB", Path("/nonexistent/gwas.db")
-        )
+    def test_gwas_installed_false_when_no_db(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path / "empty"))
         assert gwas_installed() is False
 
 
@@ -84,12 +82,11 @@ class TestGwasZipCleanup:
 
     def test_default_zip_deleted_after_build(self, tmp_path, monkeypatch, capsys):
         """Verify default cache zip is deleted after successful DB build."""
-        zip_path = tmp_path / "gwas.zip"
+        # Point data dir to tmp_path so default zip lands there
+        monkeypatch.setenv("GENECHAT_DATA_DIR", str(tmp_path))
+        zip_path = tmp_path / "gwas-catalog-associations.zip"
         with zipfile.ZipFile(str(zip_path), "w") as zf:
             zf.writestr("gwas-catalog.tsv", self._GWAS_TSV)
-
-        # Point DEFAULT_GWAS_ZIP to our test zip so it's treated as default
-        monkeypatch.setattr("genechat.gwas.DEFAULT_GWAS_ZIP", zip_path)
 
         db_path = tmp_path / "gwas.db"
         build_gwas_db(db_path=db_path)  # zip_path=None → uses default


### PR DESCRIPTION
## Summary
- Add `GENECHAT_DATA_DIR` env var to override the base data directory (default: OS-specific via platformdirs)
- Add `data_dir` field to `[databases]` in config.toml for the same override
- Resolution order: env var → config.toml → platformdirs default
- All derived paths (references/, gwas.db, lookup_tables.db) follow the override automatically
- Tilde (`~`) paths are expanded via `expanduser()`

Fixes #74

## Changes
- **config.py**: Add `get_data_dir()` with `expanduser()`, `data_dir` to `DatabasesConfig`, propagate config value (expanded) to env var in `load_config()`
- **download.py**: Replace `REFERENCES_DIR` module-level constant with dynamic `references_dir()` using `get_data_dir()`
- **gwas.py**: Replace `DEFAULT_GWAS_DB`/`DEFAULT_GWAS_ZIP`/`GWAS_DATA_DIR` constants with `default_gwas_db()`/`default_gwas_zip()` functions using `get_data_dir()`
- **scripts/build_gwas_db.py**: Update to use new function-based API
- **config.toml.example**: Document `data_dir` field with OS-agnostic default note
- **tests**: Replace `monkeypatch.setattr("...REFERENCES_DIR", ...)` with `monkeypatch.setenv("GENECHAT_DATA_DIR", ...)` throughout; add 5 new tests for `get_data_dir()`, tilde expansion, and config propagation

## Design decisions
- **Single knob**: One `data_dir` override covers references, GWAS, and lookup_tables.db rather than separate overrides per path (individual `lookup_db` and `gwas_db` settings already exist for special cases)
- **Env var as bridge**: Config.toml `data_dir` is propagated to `GENECHAT_DATA_DIR` env var in `load_config()` so that the `get_data_dir()` function returns the correct value regardless of call site
- **Env var wins**: If `GENECHAT_DATA_DIR` is already set, config.toml `data_dir` does not overwrite it

## Test plan
- [x] All 404 tests pass (5 new tests added)
- [x] ruff check passes
- [x] Copilot review — all 6 comments addressed and resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)